### PR TITLE
Fix: Correct Svelte comment syntax in App.svelte

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -287,7 +287,7 @@
       </header>
     {/if}
 
-    {* <!-- ADDED GlobalChat component --> *}
+    <!-- ADDED GlobalChat component -->
     <GlobalChat />
 
     {#if currentInvitationToShow}


### PR DESCRIPTION
Corrected a comment in `ui/src/App.svelte` that was causing a Vite pre-transform error ("Unexpected token"). The syntax `{* <!-- ... --> *}` was changed to the standard Svelte HTML comment `<!-- ... -->`.

This resolves the build issue you reported.