### PR TITLE
Debug: Add raw signal payload logging in App.svelte

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -73,6 +73,7 @@
 
   // --- Signal Handler ---
   function handleSignal(signalPayload: any) {
+      console.log("%%%% RAW SIGNAL RECEIVED BY CLIENT:", JSON.stringify(signalPayload, null, 2));
       // console.log("[App.svelte handleSignal] Received signal RAW:", JSON.stringify(signalPayload, null, 2)); // Too verbose
 
       if (signalPayload && typeof signalPayload === 'object' && signalPayload.App) {


### PR DESCRIPTION
Adds a console.log statement at the beginning of the `handleSignal` function in `ui/src/App.svelte` to output the entire raw signal payload received by the client.

This is intended to help diagnose an issue where chat messages are not appearing for the receiving agent, by verifying if the signal is reaching the receiver's UI at all.