### PR TITLE
Fix: Ensure correct sender encoding for chat messages

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -147,15 +147,16 @@
             if (rawSignal.sender && typeof rawSignal.content === 'string' && typeof rawSignal.timestamp === 'number') {
 
                 const messageTimestamp = Math.floor(rawSignal.timestamp / 1000); // Assuming microseconds -> milliseconds
+                const senderB64 = encodeHashToBase64(rawSignal.sender); // Encode sender
 
                 const chatSignal: GlobalChatMessageSignal = {
                     type: "GlobalChatMessage",
-                    sender: rawSignal.sender,    // Already AgentPubKeyB64 string from client
+                    sender: senderB64,    // Use encoded sender
                     content: rawSignal.content,
                     timestamp: messageTimestamp, // Converted to milliseconds
                 };
                 addChatMessage(chatSignal);
-                // console.log("[App.svelte handleSignal] Added chat message to store (numeric timestamp):", chatSignal); // Info
+                // console.log("[App.svelte handleSignal] Added chat message to store (numeric timestamp, encoded sender):", chatSignal); // Info
 
             // Fallback for original [seconds, nanoseconds] array format (optional, but good for robustness)
             } else if (rawSignal.sender && typeof rawSignal.content === 'string' &&
@@ -163,15 +164,16 @@
                 typeof rawSignal.timestamp[0] === 'number' && typeof rawSignal.timestamp[1] === 'number') {
                 
                 const messageTimestamp = rawSignal.timestamp[0] * 1000 + Math.floor(rawSignal.timestamp[1] / 1000000);
+                const senderB64 = encodeHashToBase64(rawSignal.sender); // Encode sender
                 
                 const chatSignal: GlobalChatMessageSignal = {
                     type: "GlobalChatMessage",
-                    sender: rawSignal.sender,
+                    sender: senderB64, // Use encoded sender
                     content: rawSignal.content,
                     timestamp: messageTimestamp,
                 };
                 addChatMessage(chatSignal);
-                // console.log("[App.svelte handleSignal] Added chat message to store (array timestamp):", chatSignal); // Info
+                // console.log("[App.svelte handleSignal] Added chat message to store (array timestamp, encoded sender):", chatSignal); // Info
             }
             else {
                 // If neither matches, then it's malformed


### PR DESCRIPTION
This commit resolves an issue where chat messages were not correctly processed and displayed on the receiver's client.

The `sender` field in the raw `GlobalChatMessage` signal payload was being received as a Uint8Array-like object. The UI, however, expects this to be a Base64 encoded string (`AgentPubKeyB64`).

The `handleSignal` function in `App.svelte` has been updated to explicitly encode the `rawSignal.sender` to Base64 using `encodeHashToBase64` before it's passed to the chat store.

This ensures that the sender's information is in the correct format, allowing messages to be properly attributed and displayed on both the sender's and receiver's clients. This commit builds upon previous fixes for timestamp parsing and Svelte comment syntax.