### PR TITLE
Feat: Refactor global chat to use targeted call_remote

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/chat.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/chat.rs
@@ -1,18 +1,45 @@
 use hdk::prelude::*;
 use crate::{Signal, ChatMessagePayload}; // Assuming ChatMessagePayload is in lib.rs or imported there
+use crate::player::get_all_player_pubkeys; // Import the new function
 
 #[hdk_extern]
 pub fn send_global_chat_message(content: String) -> ExternResult<()> {
-    let agent_info = agent_info()?;
-    let now_timestamp = sys_time()?; // hdk::prelude::holo_hash::Timestamp doesn't seem to have a `now()` or equivalent. Using sys_time() which returns a `Timestamp`.
+    let my_agent_info = agent_info()?;
+    let my_pub_key = my_agent_info.agent_latest_pubkey.clone();
+    let now_timestamp = sys_time()?;
 
     let payload = ChatMessagePayload {
         timestamp: now_timestamp,
-        sender: agent_info.agent_latest_pubkey,
+        sender: my_pub_key.clone(),
         content,
     };
 
     let signal = Signal::GlobalChatMessage(payload);
+
+    // 1. Emit locally for sender's UI
     emit_signal(&signal)?;
+
+    // 2. Get all player pubkeys
+    let all_player_pubkeys = get_all_player_pubkeys(())?; // Call the new function
+
+    // 3. Send to all other players via call_remote
+    for target_agent_key in all_player_pubkeys {
+        if target_agent_key != my_pub_key { // Don't send to self again via call_remote
+            let _ = call_remote(
+                target_agent_key.clone(),
+                "ping_2_pong", // Zome name
+                "receive_remote_signal".into(),
+                None, // Unrestricted cap grant assumed for receive_remote_signal
+                signal.clone() // Clone signal for each call
+            );
+            // Error handling for call_remote can be added if necessary,
+            // but often chat messages are fire-and-forget.
+            // Example logging if needed:
+            // match result {
+            //     Ok(_) => debug!("Successfully sent remote signal to {:?}", target_agent_key),
+            //     Err(e) => warn!("Failed to send remote signal to {:?}: {:?}", target_agent_key, e),
+            // }
+        }
+    }
     Ok(())
 }

--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/player.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/player.rs
@@ -36,6 +36,18 @@ pub fn create_player(player: Player) -> ExternResult<Record> {
     let name_anchor = anchor_for(&player.player_name.to_lowercase())?;
     create_link( name_anchor, player_action_hash.clone(), LinkTypes::PlayerNameToPlayer, (), )?;
 
+    // Link player to the "all_players" anchor
+    const ALL_PLAYERS_ANCHOR_STR: &str = "all_players";
+    let all_players_path = Path::from(ALL_PLAYERS_ANCHOR_STR);
+    // Optional: all_players_path.ensure()?; // Ensure the path entry itself exists if needed by your design
+    let all_players_anchor_hash = all_players_path.path_entry_hash()?;
+    create_link(
+        all_players_anchor_hash.clone(), // Base for the link
+        player.player_key.clone(),       // Target of the link is AgentPubKey
+        LinkTypes::AllPlayersAnchorToAgentPubKey,
+        LinkTag::new(vec![]) // Empty tag
+    )?;
+
     let record = get(player_action_hash.clone(), GetOptions::default())?.ok_or(wasm_error!( WasmErrorInner::Guest("Could not find the newly created Player".to_string()) ))?;
     Ok(record)
 }
@@ -170,4 +182,23 @@ pub fn get_player_by_name(player_name: String) -> ExternResult<Option<Record>> {
             get_original_player(action_hash)
         } else { Ok(None) }
     } else { Ok(None) }
+}
+
+#[hdk_extern]
+pub fn get_all_player_pubkeys(_: ()) -> ExternResult<Vec<AgentPubKey>> {
+    const ALL_PLAYERS_ANCHOR_STR: &str = "all_players";
+    let all_players_path = Path::from(ALL_PLAYERS_ANCHOR_STR);
+    let all_players_anchor_hash = all_players_path.path_entry_hash()?;
+
+    let links = get_links(
+        GetLinksInputBuilder::try_new(all_players_anchor_hash.clone(), LinkTypes::AllPlayersAnchorToAgentPubKey)?
+        .build()
+    )?;
+
+    let pub_keys: Vec<AgentPubKey> = links
+        .into_iter()
+        .filter_map(|link| link.target.into_agent_pub_key()) // Link target is AgentPubKey
+        .collect();
+
+    Ok(pub_keys)
 }

--- a/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/lib.rs
+++ b/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/lib.rs
@@ -59,6 +59,7 @@ pub enum LinkTypes {
     PlayerUpdates,
     PlayerToScores,
     Presence,
+    AllPlayersAnchorToAgentPubKey, // For linking the "all_players" anchor to each player's AgentPubKey
 }
 
 
@@ -141,6 +142,18 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                                 LinkTypes::PlayerUpdates => validate_player_updates_link(&create_link),
                                 LinkTypes::PlayerToScores => validate_player_to_scores_link(&create_link),
                                 LinkTypes::Presence => validate_presence_link(&create_link),
+                                LinkTypes::AllPlayersAnchorToAgentPubKey => {
+                                    // Base must be an EntryHash (the anchor)
+                                    if create_link.base_address.clone().into_entry_hash().is_none() {
+                                        return Ok(ValidateCallbackResult::Invalid("AllPlayersAnchorToAgentPubKey base must be an EntryHash (anchor)".into()));
+                                    }
+                                    // Target must be an AgentPubKey
+                                    if create_link.target_address.clone().into_agent_pub_key().is_none() {
+                                        return Ok(ValidateCallbackResult::Invalid("AllPlayersAnchorToAgentPubKey target must be an AgentPubKey".into()));
+                                    }
+                                    // Author: Anyone can create this link (typically the player themselves during registration)
+                                    Ok(ValidateCallbackResult::Valid)
+                                }
                             }
                         }
                         None => Ok(ValidateCallbackResult::Valid), // Allow unknown link types from other zomes


### PR DESCRIPTION
This commit changes the mechanism for sending global chat messages to improve reliability in environments where global `emit_signal` may not propagate effectively to all agents.

Key changes:
- **Integrity Zome (`ping_2_pong_integrity/src/lib.rs`):**
  - Added `AllPlayersAnchorToAgentPubKey` LinkType.

- **Player Coordinator Zome (`player.rs`):**
  - Modified `create_player` to link the new player's AgentPubKey to a global "all_players" anchor using the new LinkType. This allows discovery of all registered players.
  - Added `get_all_player_pubkeys` hdk_extern function to retrieve all AgentPubKeys linked to the "all_players" anchor.

- **Chat Coordinator Zome (`chat.rs`):**
  - Updated `send_global_chat_message`:
    - It still emits the signal locally for your UI.
    - It now fetches all player AgentPubKeys using the new `get_all_player_pubkeys` function.
    - It iterates through these keys and uses `call_remote` to send the `Signal::GlobalChatMessage` to each player's `receive_remote_signal` function (excluding self). This mirrors the more reliable mechanism used by game invitations.

- **Signals Coordinator Zome (`signals.rs`):**
  - Verified that the generic `receive_remote_signal` hdk_extern function is in place to receive signals sent via `call_remote` and re-emit them locally to the recipient's UI.

This approach aims to ensure that all connected players receive chat messages by sending them directly, rather than relying on global broadcast.