### PR TITLE
Fix: Correct Svelte comment syntax in Lobby.svelte

### DIFF
--- a/ui/src/ping_2_pong/game/Lobby.svelte
+++ b/ui/src/ping_2_pong/game/Lobby.svelte
@@ -190,7 +190,7 @@
             {@const isDisabled = !(user.status === 'Available')}
             <li>
               <span title={user.pubKeyB64}>
-                {user.nickname || truncatePubkey(user.pubKeyB64, 6, 4)} {/* Show nickname or shorter truncated pubkey */}
+                {user.nickname || truncatePubkey(user.pubKeyB64, 6, 4)} <!-- Show nickname or shorter truncated pubkey -->
                 {#if user.status === 'Loading'} <em class="status">(Checking...)</em>
                 {:else if user.status === 'Error'} <em class="status error">(Status Error)</em>
                 {:else if user.status === 'InGame'} <em class="status">(In Game)</em>


### PR DESCRIPTION
Corrects an "Unexpected block closing tag" error in Lobby.svelte by changing an invalid comment within a Svelte expression: `{...} {/* ... */}`
to the standard HTML comment syntax placed after the expression: `{...} <!-- ... -->`

This resolves the Vite pre-transform error.