### PR TITLE
Fix game end flow and score handling

### DIFF
--- a/ui/src/ping_2_pong/game/Dashboard.svelte
+++ b/ui/src/ping_2_pong/game/Dashboard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Leaderboard from "./Leaderboard.svelte";
+  import type { Leaderboard as LeaderboardType } from "./Leaderboard.svelte"; // For instance binding
   import Lobby from "./Lobby.svelte";
   import PlayButton from "./PlayButton.svelte";
   import GlobalChat from "../chat/GlobalChat.svelte"; // Added import
@@ -8,14 +9,25 @@
 
   const dispatch = createEventDispatcher();
 
+  let leaderboardComponent: LeaderboardType; // Variable to hold Leaderboard instance
+
   // function handlePlay() { // REMOVED - PlayButton now handles its own matchmaking logic
   //   currentRoute.set("gameplay");
   // }
+
+  export function refreshLeaderboardData() {
+    if (leaderboardComponent && typeof leaderboardComponent.fetchLeaderboard === 'function') {
+      console.log("[Dashboard.svelte] Calling fetchLeaderboard on Leaderboard component.");
+      leaderboardComponent.fetchLeaderboard();
+    } else {
+      console.warn("[Dashboard.svelte] Leaderboard component or fetchLeaderboard method not available for refresh.");
+    }
+  }
 </script>
 
 <div class="dashboard-layout">
   <div class="dashboard-col-left">
-    <Leaderboard />
+    <Leaderboard bind:this={leaderboardComponent} />
   </div>
   <div class="dashboard-col-center">
     <PlayButton />


### PR DESCRIPTION
This commit addresses several issues related to the end of a game:

1.  **"Back to Lobby" Button Visibility:**
    *   I added detailed logging in `PongGame.svelte` to trace `GameOver` signal reception and processing for Player 2 (invitee). The zome-side signal sending (`send_game_over`) was reviewed and appears robust. This should help ensure Player 2 consistently sees the "Back to Lobby" button.

2.  **"Player Already in Game" Error:**
    *   I made `handleLocalGameOver` in `PongGame.svelte` more robust. It now attempts to save scores even if the `update_game` call (to set game status to `Finished`) fails.
    *   I improved error reporting to Player 1 if DHT updates fail.
    *   The `is_player_in_ongoing_game` zome utility was verified to correctly check the latest game status against `InProgress`. The issue was likely due to `update_game` not completing and the game status remaining `InProgress` on the DHT.

3.  **Score Recording and Refresh:**
    *   Scores are now attempted to be saved by Player 1 in `handleLocalGameOver` even if the game status update to `Finished` fails.
    *   I implemented a leaderboard refresh mechanism. `Leaderboard.svelte` can now have its data refreshed by its parent. `Dashboard.svelte` exposes a method to do this, which `App.svelte` calls when a player returns to the dashboard after a game, ensuring fresh scores are displayed without a page reload.

Overall, these changes aim to make the game completion process more reliable, provide better feedback to you in case of errors, and ensure game state and scores are correctly updated and reflected in the UI.