### PR TITLE
Add extensive logging for game end and score issues

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/score.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/score.rs
@@ -2,34 +2,63 @@
 use hdk::prelude::*;
 use ping_2_pong_integrity::*;
 use crate::utils::get_game_hash_by_id; // Use helper
-use ping_2_pong_integrity::game::GameStatus;
+use ping_2_pong_integrity::game::GameStatus; // Directly from integrity
+use ping_2_pong_integrity::Game; // Assuming Game is also directly available
 
 // Maximum allowed score points.
 const MAX_POINTS: u32 = 10000; // Keep high for flexibility, game logic enforces 10
 
 #[hdk_extern]
-pub fn create_score(score: Score) -> ExternResult<Record> {
+pub fn create_score(score_input: Score) -> ExternResult<Record> { // Renamed 'score' to 'score_input' for clarity with new var 'score'
+    debug!("[score.rs] create_score: Called with input relevant parts: game_id {:?}, player {:?}, points {:?}", score_input.game_id, score_input.player, score_input.player_points);
+
     // --- Validation ---
     // Ensure the game_id corresponds to an actual Game entry
     // Note: game_id in Score struct should be the original ActionHash of the game creation
-    let game_action_hash = get_game_hash_by_id(&score.game_id)?
-        .ok_or(wasm_error!(WasmErrorInner::Guest(format!("Game ID does not exist: {}", score.game_id))))?;
+    let game_action_hash = get_game_hash_by_id(&score_input.game_id)?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!("Game ID does not exist: {}", score_input.game_id))))?;
 
     // Fetch the *latest* game state record to check status
-    let game_record = crate::game::get_latest_game(game_action_hash)?
-        .ok_or(wasm_error!(WasmErrorInner::Guest("Game record not found".into())))?;
-    let game = game_record
+    debug!("[score.rs] create_score: Fetching game record for game_id: {:?}", score_input.game_id);
+    match crate::game::get_latest_game(game_action_hash.clone()) { // game_action_hash is the original_game_hash needed by get_latest_game
+        Ok(Some(game_record)) => {
+            match game_record.entry().to_app_option::<ping_2_pong_integrity::Game>() {
+                Ok(Some(game_entry)) => {
+                    debug!("[score.rs] create_score: For game_id {:?}, current game status is: {:?}", score_input.game_id, game_entry.game_status);
+                    if game_entry.game_status != ping_2_pong_integrity::game::GameStatus::Finished {
+                        debug!("[score.rs] create_score: WARNING - Attempting to create score for a game (id: {:?}) not in 'Finished' state. Actual status: {:?}", score_input.game_id, game_entry.game_status);
+                        // Note: Original code returns error here, which is good. This log is just an additional warning.
+                        // The original error will be hit below if this condition is true.
+                    }
+                }
+                Err(e) => debug!("[score.rs] create_score: Error deserializing game entry for game_id {:?}: {:?}", score_input.game_id, e),
+                Ok(None) => debug!("[score.rs] create_score: Game entry data not found for game_id {:?}", score_input.game_id),
+            }
+        }
+        Err(e) => debug!("[score.rs] create_score: Error fetching game record for game_id {:?}: {:?}", score_input.game_id, e),
+        Ok(None) => debug!("[score.rs] create_score: No game record found for game_id {:?}", score_input.game_id),
+    }
+
+    // Re-fetch for actual validation logic (original code structure)
+    let game_record_for_validation = crate::game::get_latest_game(game_action_hash.clone())? // Use cloned game_action_hash
+        .ok_or(wasm_error!(WasmErrorInner::Guest("Game record not found for validation".into())))?;
+    let game_for_validation = game_record_for_validation
         .entry()
-        .to_app_option::<Game>()
+        .to_app_option::<Game>() // Assuming Game is directly available from integrity
         .map_err(|e| wasm_error!(WasmErrorInner::Serialize(e)))?
-        .ok_or(wasm_error!(WasmErrorInner::Guest("Invalid Game entry format".into())))?;
+        .ok_or(wasm_error!(WasmErrorInner::Guest("Invalid Game entry format for validation".into())))?;
 
     // Ensure the game status is Finished before recording score
-    if game.game_status != GameStatus::Finished {
+    if game_for_validation.game_status != GameStatus::Finished { // GameStatus directly from integrity
         return Err(wasm_error!(WasmErrorInner::Guest("Scores can only be recorded for 'Finished' games".into())));
     }
 
     // Ensure the score is being assigned to a player who was actually in the game.
+    if score_input.player != game_for_validation.player_1 && game_for_validation.player_2.as_ref() != Some(&score_input.player) {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Score must be assigned to a player who participated in the game".into()
+        )));
+    }
     if score.player != game.player_1 && game.player_2.as_ref() != Some(&score.player) {
         return Err(wasm_error!(WasmErrorInner::Guest(
             "Score must be assigned to a player who participated in the game".into()
@@ -39,29 +68,40 @@ pub fn create_score(score: Score) -> ExternResult<Record> {
     // Ensure caller is one of the players in the game? Or allow anyone to record score?
     // Let's allow anyone for now, assuming UI calls this after game ends for both players.
     // let my_pub_key = agent_info()?.agent_latest_pubkey;
-    // if my_pub_key != game.player_1 && game.player_2.as_ref() != Some(&my_pub_key) {
+    // if my_pub_key != game_for_validation.player_1 && game_for_validation.player_2.as_ref() != Some(&my_pub_key) {
     //     return Err(wasm_error!(WasmErrorInner::Guest("Only game participants can record the score".into())));
     // }
 
 
     // Validate that the score points are within a reasonable range.
-    if score.player_points > MAX_POINTS { // MAX_POINTS is high, maybe check against game win condition?
-        warn!("Score points {} exceed MAX_POINTS {}", score.player_points, MAX_POINTS);
+    if score_input.player_points > MAX_POINTS { // MAX_POINTS is high, maybe check against game win condition?
+        warn!("Score points {} exceed MAX_POINTS {}", score_input.player_points, MAX_POINTS);
         // Allow high scores for now, UI/game logic should enforce game rules like first to 10.
         // return Err(wasm_error!(WasmErrorInner::Guest("Player points exceed the maximum allowed".into())));
     }
-     if score.player_points > 100 { // Add a more reasonable sanity check
-         warn!("Recorded score {} seems high.", score.player_points);
+     if score_input.player_points > 100 { // Add a more reasonable sanity check
+         warn!("Recorded score {} seems high.", score_input.player_points);
      }
      // --- End Validation ---
 
 
     // Create the Score entry.
-    let score_action_hash = create_entry(&EntryTypes::Score(score.clone()))?;
+    let score_to_create = score_input.clone(); // Use the cloned input for creation
+    let score_action_hash = match create_entry(&EntryTypes::Score(score_to_create)) {
+        Ok(hash) => {
+            debug!("[score.rs] create_score: create_entry for Score successful, action hash: {:?}", hash);
+            hash
+        }
+        Err(e) => {
+            debug!("[score.rs] create_score: create_entry for Score failed: {:?}", e);
+            return Err(e);
+        }
+    };
 
     // Link the Score action hash from the Player's pubkey.
+    // Error handling for create_link can be added if necessary, for now assuming ? operator is sufficient
     create_link(
-        score.player.clone(),
+        score_input.player.clone(),
         score_action_hash.clone(),
         LinkTypes::PlayerToScores, // Changed from ScoreToPlayer based on convention BaseToTargets
         (),
@@ -69,16 +109,16 @@ pub fn create_score(score: Score) -> ExternResult<Record> {
 
     // Link the Score action hash from the original game's action hash.
     create_link(
-        score.game_id.clone(), // Base is the original game action hash
+        score_input.game_id.clone(), // Base is the original game action hash
         score_action_hash.clone(),
         LinkTypes::GameToScores, // Use a more descriptive name if possible, or reuse ScoreUpdates? Let's define GameToScores
-        // LinkTypes::ScoreUpdates, // ScoreUpdates implies linking Score revisions, not linking *to* a score.
         (),
     )?;
 
     // Retrieve and return the created Score record.
     let record = get(score_action_hash.clone(), GetOptions::default())?
         .ok_or(wasm_error!(WasmErrorInner::Guest("Could not find the newly created Score".to_string())))?;
+    debug!("[score.rs] create_score: Successfully created score, returning record for action: {:?}", record.action_hashed().hash);
     Ok(record)
 }
 

--- a/ui/src/ping_2_pong/game/PongGame.svelte
+++ b/ui/src/ping_2_pong/game/PongGame.svelte
@@ -479,6 +479,7 @@
             console.log("Game status updated on DHT successfully.");
        } catch (e: any) {
             console.error("CRITICAL: Error updating game status to Finished in handleLocalGameOver. Error:", e);
+            console.error("Detailed zome error object from update_game:", JSON.stringify(e, Object.getOwnPropertyNames(e), 2));
             errorMsg = `Failed to finalize game status: ${e.data?.data || e.message || "Unknown error"}. Attempting to save scores anyway.`;
             // The errorMsg should be displayed by the draw() function.
             // REMOVED return; to allow execution to continue
@@ -507,6 +508,7 @@
            console.log("Scores saved.");
        } catch (e: any) {
            console.error("Error saving scores in handleLocalGameOver. Error:", e);
+           console.error("Detailed zome error object from create_score:", JSON.stringify(e, Object.getOwnPropertyNames(e), 2));
            if (errorMsg) { // If update_game already set an error
                errorMsg += ` Additionally, failed to save scores: ${e.data?.data || e.message || "Unknown error"}.`;
            } else { // If update_game succeeded


### PR DESCRIPTION
This commit introduces comprehensive debug logging to help diagnose persistent problems related to:
- The "Player already in game" error.
- Scores remaining at 0.

Logging has been added to:
- `ui/src/ping_2_pong/game/PongGame.svelte`:
    - Detailed error objects from zome calls in `handleLocalGameOver` (for `update_game` and `create_score`) are now logged to Player 1's browser console.
- `dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/game.rs`:
    - `update_game()`: Logs input, results of internal DHT operations (updates, links), and any errors.
    - `get_latest_game()`: Logs input hash, links found, determined latest hash, and the record being returned.
- `dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/score.rs`:
    - `create_score()`: Logs input, the game status at the time of score creation (by fetching the game record), and results of DHT operations.
- `dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/utils.rs`:
    - `is_player_in_ongoing_game()`: Logs the player key, game links found, the status of games fetched via `get_latest_game`, and the function's boolean result.

These logs are intended to provide detailed insight into the state and behavior of the application when these errors occur, facilitating a more accurate diagnosis for subsequent fixes.