### PR TITLE
Fix P2 unresponsiveness with responsive canvas and update initial state

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
@@ -27,14 +27,14 @@ pub fn receive_remote_signal(signal: Signal) -> ExternResult<()> {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaddleUpdatePayload {
     pub game_id:  ActionHash,
-    pub paddle_y: u32,
+    pub relative_paddle_y: f32, // Changed from paddle_y
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BallUpdatePayload {
     pub game_id: ActionHash,
-    pub ball_x:  u32,
-    pub ball_y:  u32,
+    pub relative_ball_x: f32, // Changed
+    pub relative_ball_y: f32, // Changed
     pub ball_dx: i32,
     pub ball_dy: i32,
 }
@@ -108,7 +108,7 @@ pub fn send_paddle_update(payload: PaddleUpdatePayload) -> ExternResult<()> {
     let signal = Signal::PaddleUpdate {
         game_id:  payload.game_id.clone(),
         player:   agent_info()?.agent_latest_pubkey,
-        paddle_y: payload.paddle_y,
+        relative_paddle_y: payload.relative_paddle_y, // Use the new field from payload
     };
     emit_signal(&signal)?;
     broadcast_to_opponents(&payload.game_id, &signal)
@@ -118,8 +118,8 @@ pub fn send_paddle_update(payload: PaddleUpdatePayload) -> ExternResult<()> {
 pub fn send_ball_update(payload: BallUpdatePayload) -> ExternResult<()> {
     let signal = Signal::BallUpdate {
         game_id: payload.game_id.clone(),
-        ball_x:  payload.ball_x,
-        ball_y:  payload.ball_y,
+        relative_ball_x: payload.relative_ball_x, // Use new field
+        relative_ball_y: payload.relative_ball_y, // Use new field
         ball_dx: payload.ball_dx,
         ball_dy: payload.ball_dy,
     };


### PR DESCRIPTION
This commit addresses an issue where Player 2's game client became unresponsive (paddles and ball not moving) after the introduction of the responsive game canvas. It also corrects Player 2's initial ball velocity.

Changes:

1.  **Relative Coordinate Signaling for Game State:**
    *   Zome DNA (`lib.rs`, `signals.rs`):
        *   `Signal::PaddleUpdate` now uses `relative_paddle_y: f32` instead of `paddle_y: u32`.
        *   `Signal::BallUpdate` now uses `relative_ball_x: f32` and `relative_ball_y: f32` instead of `ball_x: u32` and `ball_y: u32`.
        *   The corresponding payload structs (`PaddleUpdatePayload`, `BallUpdatePayload`) in `signals.rs` (used as inputs to the extern functions that send signals) have also been updated to accept these relative float values.
    *   `PongGame.svelte` (UI):
        *   Player 1 (when sending updates): Now calculates paddle and ball positions as relative values (percentages of its own `canvasWidth`/`canvasHeight`) before sending them in signals. Ball velocities (`dx`, `dy`) are still sent as absolute values.
        *   Signal Reception (mainly for Player 2): When receiving `PaddleUpdate` or `BallUpdate` signals, clients now convert the incoming relative coordinates into absolute pixel values based on their *own* current `canvasWidth` and `canvasHeight`. This ensures correct rendering even if you and Player 2 have different canvas sizes/aspect ratios.

2.  **Corrected Initial Ball Velocity for Player 2:**
    *   In `PongGame.svelte`'s `initializeGame` function, Player 2 now initializes `ball.dx` and `ball.dy` to `0`. This ensures Player 2's ball remains stationary until the first `BallUpdate` signal is received from Player 1, preventing desynchronized movement at the start.

These changes should restore multiplayer synchronization for Player 2 with the responsive canvas system.