### PR TITLE
Revert signal coordinates to u32/absolute and paddle speed to 18

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
@@ -27,14 +27,14 @@ pub fn receive_remote_signal(signal: Signal) -> ExternResult<()> {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaddleUpdatePayload {
     pub game_id:  ActionHash,
-    pub relative_paddle_y: f32, // Changed from paddle_y
+    pub paddle_y: u32, // Reverted from relative_paddle_y: f32
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BallUpdatePayload {
     pub game_id: ActionHash,
-    pub relative_ball_x: f32, // Changed
-    pub relative_ball_y: f32, // Changed
+    pub ball_x: u32, // Reverted from relative_ball_x: f32
+    pub ball_y: u32, // Reverted from relative_ball_y: f32
     pub ball_dx: i32,
     pub ball_dy: i32,
 }
@@ -108,7 +108,7 @@ pub fn send_paddle_update(payload: PaddleUpdatePayload) -> ExternResult<()> {
     let signal = Signal::PaddleUpdate {
         game_id:  payload.game_id.clone(),
         player:   agent_info()?.agent_latest_pubkey,
-        relative_paddle_y: payload.relative_paddle_y, // Use the new field from payload
+        paddle_y: payload.paddle_y, // Reverted to use paddle_y
     };
     emit_signal(&signal)?;
     broadcast_to_opponents(&payload.game_id, &signal)
@@ -118,8 +118,8 @@ pub fn send_paddle_update(payload: PaddleUpdatePayload) -> ExternResult<()> {
 pub fn send_ball_update(payload: BallUpdatePayload) -> ExternResult<()> {
     let signal = Signal::BallUpdate {
         game_id: payload.game_id.clone(),
-        relative_ball_x: payload.relative_ball_x, // Use new field
-        relative_ball_y: payload.relative_ball_y, // Use new field
+        ball_x: payload.ball_x, // Reverted
+        ball_y: payload.ball_y, // Reverted
         ball_dx: payload.ball_dx,
         ball_dy: payload.ball_dy,
     };

--- a/ui/src/ping_2_pong/game/PongGame.svelte
+++ b/ui/src/ping_2_pong/game/PongGame.svelte
@@ -29,7 +29,7 @@
   const PADDLE_HEIGHT = 100;
   const BALL_RADIUS = 10;
   const WINNING_SCORE = 10;
-  const PADDLE_SPEED = 25;
+  const PADDLE_SPEED = 18;
   const UPDATE_INTERVAL = 50; // ms interval for sending signal updates
 
   // Reactive Canvas Dimensions
@@ -265,11 +265,11 @@
 
     // Prepare payload matching the backend's PaddleUpdatePayload struct
     const currentPaddleY = isPlayer1 ? paddle1Y : paddle2Y;
-    const relativeY = canvasHeight > 0 ? currentPaddleY / canvasHeight : 0.5; // Default to center if canvasHeight is 0
+    const absoluteY = Math.round(currentPaddleY);
 
     const payload = {
         game_id: gameId, // The original ActionHash identifying the game
-        relative_paddle_y: relativeY
+        paddle_y: absoluteY
     };
 
     try {
@@ -290,14 +290,14 @@
     lastBallUpdate = now; // Update timestamp
 
     // Prepare payload matching the backend's BallUpdatePayload struct
-    const relativeX = canvasWidth > 0 ? ball.x / canvasWidth : 0.5;
-    const relativeY = canvasHeight > 0 ? ball.y / canvasHeight : 0.5;
+    const absoluteX = Math.round(ball.x);
+    const absoluteY = Math.round(ball.y);
 
     const payload = {
         game_id: gameId, // The original ActionHash identifying the game
-        relative_ball_x: relativeX,
-        relative_ball_y: relativeY,
-        ball_dx: Math.round(ball.dx), // dx/dy are still absolute
+        ball_x: absoluteX,
+        ball_y: absoluteY,
+        ball_dx: Math.round(ball.dx),
         ball_dy: Math.round(ball.dy)
     };
 
@@ -343,17 +343,16 @@
         switch (s.type) {
           case "PaddleUpdate":
             if (encodeHashToBase64(s.player) !== meB64) {
-              const absoluteY = s.relative_paddle_y * canvasHeight;
-              if (isPlayer1) paddle2Y = absoluteY;
-              else           paddle1Y = absoluteY;
+              if (isPlayer1) paddle2Y = s.paddle_y;
+              else           paddle1Y = s.paddle_y;
             }
             break;
 
           case "BallUpdate":
             if (!isPlayer1) {
-              ball.x = s.relative_ball_x * canvasWidth;
-              ball.y = s.relative_ball_y * canvasHeight;
-              ball.dx = s.ball_dx; // dx/dy are still absolute
+              ball.x = s.ball_x;
+              ball.y = s.ball_y;
+              ball.dx = s.ball_dx;
               ball.dy = s.ball_dy;
             }
             break;


### PR DESCRIPTION
This commit reverts changes related to using f32 relative coordinates for game state signals, as this introduced an issue where paddles became unresponsive for both players. The system is reverted to a state where:
- Paddle speed is 18.
- Game state signals (paddle and ball positions) use u32 absolute pixel coordinates.

Changes include:
- `PongGame.svelte`:
    - `PADDLE_SPEED` constant set back to 18.
    - `sendPaddleUpdate` and `sendBallUpdate` now calculate and send absolute u32 pixel coordinates (rounded) with original field names (`paddle_y`, `ball_x`, `ball_y`).
    - `subscribeToGameSignals` now processes incoming `PaddleUpdate` and `BallUpdate` signals as direct u32 absolute pixel values.
- Zome DNA (`signals.rs` and `lib.rs`):
    - `PaddleUpdatePayload` and `BallUpdatePayload` structs in `signals.rs` reverted to use `paddle_y: u32`, `ball_x: u32`, `ball_y: u32`.
    - Extern functions `send_paddle_update` and `send_ball_update` in `signals.rs` construct the `Signal` enum variants with these u32 absolute coordinate fields.
    - `Signal::PaddleUpdate` and `Signal::BallUpdate` enum variants in `lib.rs` reverted to define fields as `paddle_y: u32`, `ball_x: u32`, `ball_y: u32`.

This reversion aims to restore Player 1's paddle functionality. Player 2 synchronization issues with the responsive canvas when canvas sizes differ will need to be re-addressed with a different strategy.