### PR TITLE
I've fixed the DNA compilation error that was happening because of a …

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs
@@ -71,12 +71,12 @@ pub enum Signal {
     PaddleUpdate {
         game_id: ActionHash,
         player: AgentPubKey,
-        relative_paddle_y: f32, // Changed from paddle_y: u32
+        paddle_y: u32, // Reverted from relative_paddle_y: f32
     },
     BallUpdate {
         game_id: ActionHash,
-        relative_ball_x: f32, // Changed from ball_x: u32
-        relative_ball_y: f32, // Changed from ball_y: u32
+        ball_x: u32, // Reverted from relative_ball_x: f32
+        ball_y: u32, // Reverted from relative_ball_y: f32
         ball_dx: i32,
         ball_dy: i32,
     },


### PR DESCRIPTION
…mismatch in signal coordinates.

Here's a summary of what I did:

In `dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs`:
- In `Signal::PaddleUpdate`, I renamed the field `relative_paddle_y: u32` back to `paddle_y: u32`.
- In `Signal::BallUpdate`, I renamed the fields `relative_ball_x: u32` back to `ball_x: u32` and `relative_ball_y: u32` back to `ball_y: u32`.

These changes, along with previous adjustments, should restore the game state signaling for paddle and ball updates to use `u32` absolute pixel coordinates and the correct field names. I also set the paddle speed to 18. This should allow the DNA to compile and restore Player 1 functionality.