### PR TITLE
It looks like you're working on a fix for Player 2 synchronization is…

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
@@ -27,16 +27,19 @@ pub fn receive_remote_signal(signal: Signal) -> ExternResult<()> {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaddleUpdatePayload {
     pub game_id:  ActionHash,
-    pub paddle_y: u32, // Reverted from relative_paddle_y: f32
+    pub paddle_y: u32,
+    pub sender_canvas_height: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BallUpdatePayload {
     pub game_id: ActionHash,
-    pub ball_x: u32, // Reverted from relative_ball_x: f32
-    pub ball_y: u32, // Reverted from relative_ball_y: f32
+    pub ball_x: u32,
+    pub ball_y: u32,
     pub ball_dx: i32,
     pub ball_dy: i32,
+    pub sender_canvas_width: u32,
+    pub sender_canvas_height: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -108,7 +111,8 @@ pub fn send_paddle_update(payload: PaddleUpdatePayload) -> ExternResult<()> {
     let signal = Signal::PaddleUpdate {
         game_id:  payload.game_id.clone(),
         player:   agent_info()?.agent_latest_pubkey,
-        paddle_y: payload.paddle_y, // Reverted to use paddle_y
+        paddle_y: payload.paddle_y,
+        sender_canvas_height: payload.sender_canvas_height, // Added
     };
     emit_signal(&signal)?;
     broadcast_to_opponents(&payload.game_id, &signal)
@@ -118,10 +122,12 @@ pub fn send_paddle_update(payload: PaddleUpdatePayload) -> ExternResult<()> {
 pub fn send_ball_update(payload: BallUpdatePayload) -> ExternResult<()> {
     let signal = Signal::BallUpdate {
         game_id: payload.game_id.clone(),
-        ball_x: payload.ball_x, // Reverted
-        ball_y: payload.ball_y, // Reverted
+        ball_x: payload.ball_x,
+        ball_y: payload.ball_y,
         ball_dx: payload.ball_dx,
         ball_dy: payload.ball_dy,
+        sender_canvas_width: payload.sender_canvas_width,   // Added
+        sender_canvas_height: payload.sender_canvas_height, // Added
     };
     emit_signal(&signal)?;
     broadcast_to_opponents(&payload.game_id, &signal)


### PR DESCRIPTION
…sues on a responsive canvas, specifically relating to how dimensions are handled. Here's a breakdown of the changes:

This commit resolves an issue where Player 2's game client would be unresponsive or display game elements incorrectly after the canvas was made responsive. This was due to Player 2 misinterpreting absolute pixel coordinates sent by Player 1 on its own differently-sized canvas.

The fix involves sending the sender's canvas dimensions along with the absolute coordinates, allowing the receiver to scale them appropriately:

1.  **Zome DNA Changes (`signals.rs`, `lib.rs`):**
    *   The `PaddleUpdate` signal and its corresponding payload struct (`PaddleUpdatePayload`) now include a `sender_canvas_height: u32` field.
    *   The `BallUpdate` signal and its payload struct (`BallUpdatePayload`) now include `sender_canvas_width: u32` and `sender_canvas_height: u32` fields.
    *   Extern functions in `signals.rs` were updated to populate these new fields when constructing the signals.

2.  **UI `PongGame.svelte` Changes:**
    *   When sending paddle or ball updates, the client now includes its current `canvasWidth` and/or `canvasHeight` in the payload to the zome.
    *   When receiving `PaddleUpdate` or `BallUpdate` signals, the client (especially Player 2) now:
        a. Reads the sender's canvas dimensions from the signal.
        b. Calculates a relative position (0.0-1.0) using the received absolute coordinate and the sender's dimension.
        c. Converts this relative position back to an absolute pixel coordinate based on its *own* current canvas dimensions.
        d. Applies this correctly scaled local coordinate to its game state (paddle/ball positions).

This ensures that game state appears synchronized across clients even if their responsive canvas sizes differ. Ball velocities (`dx`, `dy`) are still transmitted as absolute values.