### PR TITLE
I've fixed the DNA compilation for sender canvas dimensions in signals.

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs
@@ -71,14 +71,17 @@ pub enum Signal {
     PaddleUpdate {
         game_id: ActionHash,
         player: AgentPubKey,
-        paddle_y: u32, // Reverted from relative_paddle_y: f32
+        paddle_y: u32,
+        sender_canvas_height: u32, // Added field
     },
     BallUpdate {
         game_id: ActionHash,
-        ball_x: u32, // Reverted from relative_ball_x: f32
-        ball_y: u32, // Reverted from relative_ball_y: f32
+        ball_x: u32,
+        ball_y: u32,
         ball_dx: i32,
         ball_dy: i32,
+        sender_canvas_width: u32,  // Added field
+        sender_canvas_height: u32, // Added field
     },
     ScoreUpdate {
         game_id: ActionHash,


### PR DESCRIPTION
This commit resolves a DNA compilation error that occurred after you added sender canvas dimension fields to signal payload structs. The `Signal` enum definition in `lib.rs` was not updated to include these new fields, causing a mismatch with how signals were constructed in `signals.rs`.

Here are the changes I made in `dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs`:
- In the `Signal::PaddleUpdate` variant, I added the field `sender_canvas_height: u32`.
- In the `Signal::BallUpdate` variant, I added the fields `sender_canvas_width: u32` and `sender_canvas_height: u32`.

These changes align the `Signal` enum definition with its usage and the data being sent (including the sender's canvas dimensions for coordinate scaling), allowing the DNA to compile successfully. This commit includes all previous changes related to implementing responsive canvas synchronization.