### PR TITLE
Fix: Add speculative reactivity nudge for P1 paddle

### DIFF
--- a/ui/src/ping_2_pong/game/PongGame.svelte
+++ b/ui/src/ping_2_pong/game/PongGame.svelte
@@ -241,6 +241,7 @@
         paddle1Y = Math.min(canvasHeight - PADDLE_HEIGHT, paddle1Y + PADDLE_SPEED); // Move down, clamp at bottom
         moved = true;
       }
+      if (moved) paddle1Y = paddle1Y; // Force Svelte to see assignment for reactivity
     // Player 2 controls
     } else if (isPlayer2) {
       if (e.key === "ArrowUp" || e.key === "w" || e.key === "W") {


### PR DESCRIPTION
I've added a self-assignment to `paddle1Y` in `PongGame.svelte`'s `handleKeyDown` function after it's updated. This is a speculative attempt to ensure Svelte's reactivity system picks up the change for visual rendering, addressing an issue where your Agent 1's paddle variable was reportedly updating but not its visual representation.

This commit is made alongside previous changes aimed at improving error feedback for Agent 2's client if initialization fails.