### PR TITLE
Fix: Remove sender_canvas_width/height from signals

### DIFF
--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/lib.rs
@@ -72,7 +72,6 @@ pub enum Signal {
         game_id: ActionHash,
         player: AgentPubKey,
         paddle_y: u32,
-        sender_canvas_height: u32, // Added field
     },
     BallUpdate {
         game_id: ActionHash,
@@ -80,8 +79,6 @@ pub enum Signal {
         ball_y: u32,
         ball_dx: i32,
         ball_dy: i32,
-        sender_canvas_width: u32,  // Added field
-        sender_canvas_height: u32, // Added field
     },
     ScoreUpdate {
         game_id: ActionHash,

--- a/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
+++ b/dnas/ping_2_pong/zomes/coordinator/ping_2_pong/src/signals.rs
@@ -28,7 +28,6 @@ pub fn receive_remote_signal(signal: Signal) -> ExternResult<()> {
 pub struct PaddleUpdatePayload {
     pub game_id:  ActionHash,
     pub paddle_y: u32,
-    pub sender_canvas_height: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -38,8 +37,6 @@ pub struct BallUpdatePayload {
     pub ball_y: u32,
     pub ball_dx: i32,
     pub ball_dy: i32,
-    pub sender_canvas_width: u32,
-    pub sender_canvas_height: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -112,7 +109,6 @@ pub fn send_paddle_update(payload: PaddleUpdatePayload) -> ExternResult<()> {
         game_id:  payload.game_id.clone(),
         player:   agent_info()?.agent_latest_pubkey,
         paddle_y: payload.paddle_y,
-        sender_canvas_height: payload.sender_canvas_height, // Added
     };
     emit_signal(&signal)?;
     broadcast_to_opponents(&payload.game_id, &signal)
@@ -126,8 +122,6 @@ pub fn send_ball_update(payload: BallUpdatePayload) -> ExternResult<()> {
         ball_y: payload.ball_y,
         ball_dx: payload.ball_dx,
         ball_dy: payload.ball_dy,
-        sender_canvas_width: payload.sender_canvas_width,   // Added
-        sender_canvas_height: payload.sender_canvas_height, // Added
     };
     emit_signal(&signal)?;
     broadcast_to_opponents(&payload.game_id, &signal)

--- a/ui/src/ping_2_pong/game/PongGame.svelte
+++ b/ui/src/ping_2_pong/game/PongGame.svelte
@@ -270,7 +270,6 @@
     const payload = {
         game_id: gameId, // The original ActionHash identifying the game
         paddle_y: absoluteY,
-        sender_canvas_height: canvasHeight,
     };
 
     try {
@@ -300,8 +299,6 @@
         ball_y: absoluteY,
         ball_dx: Math.round(ball.dx),
         ball_dy: Math.round(ball.dy),
-        sender_canvas_width: canvasWidth,
-        sender_canvas_height: canvasHeight,
     };
 
     try {
@@ -346,10 +343,7 @@
         switch (s.type) {
           case "PaddleUpdate":
             if (encodeHashToBase64(s.player) !== meB64) {
-              // s is the signal payload, e.g., s.paddle_y, s.sender_canvas_height
-              const senderH = s.sender_canvas_height;
-              const relY = senderH > 0 ? s.paddle_y / senderH : 0.5;
-              const localAbsY = relY * canvasHeight; // receiver's canvasHeight
+              const localAbsY = s.paddle_y; // Directly use paddle_y
 
               if (isPlayer1) { // This client is P1, signal is about P2's paddle
                 paddle2Y = localAbsY;
@@ -361,15 +355,8 @@
 
           case "BallUpdate":
             if (!isPlayer1) {
-              // s is the signal payload, e.g., s.ball_x, s.sender_canvas_width
-              const senderW = s.sender_canvas_width;
-              const senderH = s.sender_canvas_height;
-
-              const relX = senderW > 0 ? s.ball_x / senderW : 0.5;
-              const relY = senderH > 0 ? s.ball_y / senderH : 0.5;
-
-              ball.x = relX * canvasWidth;  // receiver's canvasWidth
-              ball.y = relY * canvasHeight; // receiver's canvasHeight
+              ball.x = s.ball_x; // Directly use ball_x
+              ball.y = s.ball_y; // Directly use ball_y
               ball.dx = s.ball_dx;
               ball.dy = s.ball_dy;
             }


### PR DESCRIPTION
I removed the `sender_canvas_width` and `sender_canvas_height` fields from the `PaddleUpdate` and `BallUpdate` signals and their corresponding payloads. This change was made based on your feedback suggesting these fields, remnants of a previous resizable canvas design, were causing game malfunctions.

Modifications include:
- Updated Signal enum definitions in DNA (lib.rs).
- Updated signal payload structs and extern sending functions in DNA (signals.rs).
- Updated UI (PongGame.svelte) to no longer send these fields in payloads.
- Updated UI (PongGame.svelte) to no longer expect or use these fields when receiving signals, simplifying coordinate handling.
- Reviewed TypeScript types (types.ts); no explicit definitions for these signal types were found to modify.

This comprehensive removal aims to simplify signal data and resolve issues related to paddle and ball movement.