### PR TITLE
Fix: Prevent negative ball coordinates in sendBallUpdate payload

### DIFF
--- a/ui/src/ping_2_pong/game/PongGame.svelte
+++ b/ui/src/ping_2_pong/game/PongGame.svelte
@@ -290,13 +290,17 @@
     lastBallUpdate = now; // Update timestamp
 
     // Prepare payload matching the backend's BallUpdatePayload struct
-    const absoluteX = Math.round(ball.x);
-    const absoluteY = Math.round(ball.y);
+    // Ensure values sent as u32 to the DNA are not negative.
+    const clampedBallX = Math.max(0, ball.x);
+    const clampedBallY = Math.max(0, ball.y);
+
+    const absoluteX = Math.round(clampedBallX);
+    const absoluteY = Math.round(clampedBallY);
 
     const payload = {
         game_id: gameId, // The original ActionHash identifying the game
-        ball_x: absoluteX,
-        ball_y: absoluteY,
+        ball_x: absoluteX, // Will be non-negative
+        ball_y: absoluteY, // Will be non-negative
         ball_dx: Math.round(ball.dx),
         ball_dy: Math.round(ball.dy),
     };


### PR DESCRIPTION
I've modified PongGame.svelte to ensure that ball_x and ball_y coordinates are clamped to be non-negative (>= 0) before being sent in the sendBallUpdate signal payload.

This change addresses a Deserialize error in the DNA's send_ball_update zome function, which occurred when negative coordinate values were sent from the UI for fields that the DNA expected to be unsigned integers (u32). Clamping these values on the UI side before sending ensures compatibility with the DNA's type expectations.