### PR TITLE
Here's my latest commit, addressing several compilation errors in the…

### DIFF
--- a/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/game_stats.rs
+++ b/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/game_stats.rs
@@ -2,7 +2,7 @@ use hdk::prelude::*;
 use holo_hash::{ActionHash, AgentPubKey};
 
 #[hdk_entry_helper]
-#[derive(Clone)]
+#[derive(Clone, PartialEq)] // Added PartialEq
 pub struct GameStats {
     pub game_id: ActionHash,
     pub player_1: AgentPubKey,

--- a/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/game_stats_validation.rs
+++ b/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/game_stats_validation.rs
@@ -1,7 +1,6 @@
 use hdk::prelude::*;
 use crate::GameStats;
 
-#[hdk_extern]
 pub fn validate_create_game_stats(
     _action: SignedActionHashed,
     _game_stats: GameStats,
@@ -10,7 +9,6 @@ pub fn validate_create_game_stats(
     Ok(ValidateCallbackResult::Valid)
 }
 
-#[hdk_extern]
 pub fn validate_update_game_stats(
     _action: SignedActionHashed,
     _game_stats: GameStats,
@@ -21,7 +19,6 @@ pub fn validate_update_game_stats(
     Ok(ValidateCallbackResult::Valid)
 }
 
-#[hdk_extern]
 pub fn validate_delete_game_stats(
     _action: SignedActionHashed,
     _original_action: SignedActionHashed,

--- a/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/lib.rs
+++ b/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/lib.rs
@@ -310,7 +310,7 @@ fn validate_player_updates_link(create_link: &CreateLink) -> ExternResult<Valida
 
 fn validate_player_to_scores_link(create_link: &CreateLink) -> ExternResult<ValidateCallbackResult> {
     // Base Check: Must be an AgentPubKey
-     let base_agent = create_link.base_address.clone().into_agent_pub_key()
+     let _base_agent = create_link.base_address.clone().into_agent_pub_key() // Changed to _base_agent
          .ok_or(wasm_error!(WasmErrorInner::Guest("PlayerToScores base must be an AgentPubKey".into())))?;
     // Target Check: Must be ActionHash
     if create_link.target_address.clone().into_action_hash().is_none() {


### PR DESCRIPTION
… ping_2_pong_integrity zome:

1.  I removed the `#[hdk_extern]` attribute from validation functions (`validate_create_game_stats`, `validate_update_game_stats`, `validate_delete_game_stats`) in `game_stats_validation.rs` as these are not direct extern entry points.
2.  I ensured `validate_create_game_stats` is public and its module `game_stats_validation` is publicly exported in `lib.rs`.
3.  I added `#[derive(PartialEq)]` to the `GameStats` struct in `game_stats.rs` to resolve issues with equality comparisons.
4.  I addressed an unused variable warning for `base_agent` in `validate_player_to_scores_link` in `lib.rs` by prefixing it with an underscore.
5.  I verified that other reported unused imports (`ActionHash`, `AgentPubKey` in `lib.rs` and `GameStats` in `game_stats_validation.rs`) are actually in use and retained them.

These changes should allow the integrity zome to compile successfully.