### PR TITLE
fix: Resolve final integrity zome compilation errors

### DIFF
--- a/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/lib.rs
+++ b/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/lib.rs
@@ -1,6 +1,6 @@
 // ping_2_pong/dnas/ping_2_pong/zomes/integrity/ping_2_pong/src/lib.rs
 use hdk::prelude::*;
-use holo_hash::{ActionHash, AgentPubKey};
+// use holo_hash::{ActionHash, AgentPubKey}; // Commented out as types are likely from hdk::prelude
 
 // Import entry definitions
 pub mod game;
@@ -91,7 +91,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                                             // Calls to score/stats validation are kept, but their internals will change
                                             EntryTypes::Score(score) => score_validation::validate_create_score(signed_action, score),
                                             EntryTypes::Statistics(statistics) => statistics_validation::validate_create_statistics(signed_action, statistics),
-                                            EntryTypes::GameStats(game_stats) => game_stats_validation::validate_create_game_stats(signed_action, game_stats), // Added for GameStats
+                                            EntryTypes::GameStats(game_stats) => game_stats_validation::validate_create_game_stats(signed_action.clone(), game_stats), // Cloned signed_action
                                             EntryTypes::Presence(presence) => presence_validation::validate_create_presence(signed_action, presence),
                                             EntryTypes::AnchorPath(_) => Ok(ValidateCallbackResult::Valid), // Anchor paths are structural
                                         }


### PR DESCRIPTION
This commit addresses the remaining compilation issues in the ping_2_pong_integrity zome:

1.  I fixed a type mismatch in `lib.rs` when calling `validate_create_game_stats`. The `signed_action` argument is now passed as `signed_action.clone()` to match the expected owned type `SignedHashed<Action>`.
2.  I commented out the specific import `use holo_hash::{ActionHash, AgentPubKey};` in `lib.rs`. This is to resolve a persistent compiler warning about these imports being unused, likely because these types are being provided via the `hdk::prelude::*;` import.

These changes should allow the integrity zome to compile without errors or warnings.